### PR TITLE
Add names to workflow jobs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,29 +5,30 @@ name: code-quality
 on:
   pull_request:
     branches:
-      - "*"
+      - '*'
   push:
     branches:
       - main
 
 jobs:
   build:
+    name: Code Quality
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install uv and Python
-      uses: astral-sh/setup-uv@v6
-      with:
-        python-version: "3.11"
-        activate-environment: true
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.11'
+          activate-environment: true
 
-    - name: Install pre-commit
-      run: |
-        uv sync --only-group lint
-        uv run pre-commit install
+      - name: Install pre-commit
+        run: |
+          uv sync --only-group lint
+          uv run pre-commit install
 
-    - name: Run code-quality checks
-      run: uv run pre-commit run --all-files
+      - name: Run code-quality checks
+        run: uv run pre-commit run --all-files

--- a/.github/workflows/install-import.yml
+++ b/.github/workflows/install-import.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   install-and-import:
+    name: Install and Import
 
     runs-on: ubuntu-latest
 
@@ -20,7 +21,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.11"
+          python-version: '3.11'
           activate-environment: true
 
       - name: Install package using uv

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,34 +5,35 @@ name: unit-tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 jobs:
   build:
+    name: Unit Tests
 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ['3.10', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }} and uv
-      id: setup-uv-python
-      uses: astral-sh/setup-uv@v6
-      with:
-        python-version: ${{ matrix.python-version }}
-        enable-cache: true
-        cache-dependency-glob: |
+      - name: Set up Python ${{ matrix.python-version }} and uv
+        id: setup-uv-python
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock
 
-    - name: Install dependencies
-      run: uv sync --all-extras --dev
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
 
-    - name: Test with pytest
-      run: uv run pytest -n logical
+      - name: Test with pytest
+        run: uv run pytest -n logical


### PR DESCRIPTION
Add a `name` attribute to all workflow jobs already defined in the repository. This allows identifying jobs when configuring branch protection rules.