### PR TITLE
Add introductory text to documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,7 @@ autodoc_default_options = {
     "members": True,  # Generate documentation for module members
     "special-members": "__init__",  # Also generate docs for __init__ methods
     "inherited-members": False,  # Exclude inherited members from documentation
+    "show-inheritance": True,  # Lists bases in class documention
 }
 autodoc_member_order = "bysource"
 autoclass_content = "class"  # Use the class docstring, not the docstring of its __init__ method

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx.ext.napoleon",  # Enable parsing of Google-style docstrings
     # Note: This requires 'pandoc' to be installed on the system
     "nbsphinx",  # Include Jupyter Notebooks
+    "sphinx_copybutton",
 ]
 
 templates_path = ["_templates"]
@@ -51,6 +52,11 @@ autodoc_default_options = {
 }
 autodoc_member_order = "bysource"
 autoclass_content = "class"  # Use the class docstring, not the docstring of its __init__ method
+
+# -- Copybutton
+
+# Exclude prompts (.gp) and outputs (.go) when copying code blocks
+copybutton_exclude = ".gp, .go"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,11 @@ It adds the following functionalities:
 
 The best way to get started is by following one of the :doc:`notebooks <notebooks>`, which provide a hands-on introduction to the usage of the library's modules while also explaining some of the theoretical concepts involved. Furthermore, an :doc:`API reference <api>` is provided.
 
+.. warning::
+    The ``Explainer``\ s implemented here rely on undocumented implementation details of ``scikit-learn`` for extracting training data from the model they explain.
+    As a result, compatibility is not guaranteed across versions, and these implementations may break with future updates of ``scikit-learn``.
+    The functionality has been tested and is confirmed to work only for ``scikit-learn==1.7.0``.
+
 Contents
 ~~~~~~~~
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 The ``shapiq_student`` Python package
 =====================================
 
-The ``shapiq_student`` package is an extension to the the ``shapiq`` library for approximating Shapley interactions and explaining machine learning models.
+The ``shapiq_student`` package is an extension to the ``shapiq`` library for explaining machine learning models with Shapley interactions.
 It adds the following functionalities:
 
 1. **Explainers:** Easy-to-use explainers implementing efficient algorithms for explaining nearest neighbor models, including unweighted and weighted $k$-nearest neighbor classifiers, as well as threshold nearest neighbor classifiers

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,25 +37,27 @@ Here's a short example showing how to explain the prediction of a weighted :math
 
 .. code-block:: python
 
-   >>> from sklearn.neighbors import KNeighborsClassifier
-   >>> from shapiq_student.explainer.knn import KNNExplainer, interaction_values_to_array
-   >>>
-   >>> X_train, X_test, y_train, y_test = ...  # Load some data set
-   >>> # Created a weighted classifier using `weights="distance"`
-   >>> model = KNeighborsClassifier(n_neighbors=7, weights="distance")
-   >>> model.fit(X_train, y_train)
-   >>>
-   >>> # Explain the prediction for class 0
-   >>> explainer = KNNExplainer(model, class_index=0)
-   >>> type(explainer)  # Explainer for weighted KNN models was selected automatically
-   <class 'shapiq_student.explainer.knn.weighted_knn.WeightedKNNExplainer'>
-   >>>
-   >>> iv = explainer.explain(X_test[0])
-   >>> sv = interaction_values_to_array(iv)  # Convert to array for easier handling
-   >>> sv
-   array([ 0.04347826, -0.00197628,  0.07894378, ... ])
-   >>> sv.shape[0] == X_train.shape[0]  # Every training data point is assigned a Shapley Value
-   True
+    >>> from sklearn.neighbors import KNeighborsClassifier
+    >>> from sklearn.datasets import make_classification
+    >>> from shapiq_student.explainer.knn import KNNExplainer, interaction_values_to_array
+    >>> from sklearn.model_selection import train_test_split
+    >>>
+    >>> X, y = make_classification(n_samples=40)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25)
+    >>> # Create a weighted classifier using `weights="distance"`
+    >>> model = KNeighborsClassifier(n_neighbors=7, weights="distance")
+    >>> model.fit(X_train, y_train)
+    KNeighborsClassifier(n_neighbors=7, weights='distance')
+    >>> # Explain the prediction for class 0
+    >>> explainer = KNNExplainer(model, class_index=0)
+    >>> type(explainer)  # Explainer for weighted KNN models is selected automatically
+    <class 'shapiq_student.explainer.knn.weighted_knn.WeightedKNNExplainer'>
+    >>> iv = explainer.explain(X_test[0])
+    >>> sv = interaction_values_to_array(iv)  # Convert to array for easier handling
+    >>> sv
+    array([ 0.06971687,  0.03333333,  0.09914777, ... ])
+    >>> sv.shape[0] == X_train.shape[0]  # Every training data point is assigned a Shapley Value
+    True
 
 Imputers
 ~~~~~~~~

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,9 @@ Explainers
 
 Here's a short example showing how to explain the prediction of a weighted :math:`k`-nearest neighbors model:
 
+..
+    TODO: Make sure all code blocks are ready to be copied and executed (don't contain any '...' in the instructions etc.)
+
 .. code-block:: python
 
    >>> from sklearn.neighbors import KNeighborsClassifier

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,21 @@ Details about the library's interfaces can be found in the :doc:`API reference <
 
 .. _quick-start:
 
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   Notebooks <notebooks>
+
+.. toctree::
+   :maxdepth: 2
+
+   api
+
+   citations
+
 Quick Start
 -----------
 
@@ -97,18 +112,3 @@ This example uses the ``GaussianImputer`` to explain the prediction of a random 
             (1, 6): 0.3318342718849081
             # ... more interactions
     )
-
-Contents
---------
-
-.. toctree::
-   :maxdepth: 2
-
-   Notebooks <notebooks>
-
-.. toctree::
-   :maxdepth: 2
-
-   api
-
-   citations

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,8 +48,8 @@ Here's a short example showing how to explain the prediction of a weighted :math
     >>> model = KNeighborsClassifier(n_neighbors=7, weights="distance")
     >>> model.fit(X_train, y_train)
     KNeighborsClassifier(n_neighbors=7, weights='distance')
-    >>> # Explain the prediction for class 0
-    >>> explainer = KNNExplainer(model, class_index=0)
+    >>>
+    >>> explainer = KNNExplainer(model, class_index=0) # Explain the prediction for class 0
     >>> type(explainer)  # Explainer for weighted KNN models is selected automatically
     <class 'shapiq_student.explainer.knn.weighted_knn.WeightedKNNExplainer'>
     >>> iv = explainer.explain(X_test[0])
@@ -85,6 +85,7 @@ This example uses the ``GaussianImputer`` to explain the prediction of a random 
     ... )
     >>> model.fit(X_train, y_train)
     RandomForestRegressor(...)
+    >>>
     >>> gaussian_imputer = GaussianImputer(model=model.predict, data=X_train, n_mc_samples=100)
     >>> explainer = TabularExplainer(
     ...     model=model, data=X_train, index="SII", max_order=2, imputer=gaussian_imputer

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,17 @@
 The ``shapiq_student`` Python package
 =====================================
 
-TODO: Add a package description here.
+The ``shapiq_student`` package is an extension to the the ``shapiq`` library for approximating Shapley interactions and explaining machine learning models.
+It adds the following functionalities:
+
+1. **Explainers:** Easy-to-use explainers implementing efficient algorithms for explaining nearest neighbor models, including unweighted and weighted $k$-nearest neighbor classifiers, as well as threshold nearest neighbor classifiers.
+2. **Imputers:** Provides a *Gaussian* imputer for background data with normally distributed features, and its extension, the *Gaussian copula* imputer, suitable for arbitrary, non-normally distributed data
+3. **Coalition Finding:** Implements an efficient, heuristic algorithm for finding maximal and minimal coalitions for a (simplified) game
+
+The best way to get started is by following one of the :doc:`notebooks <notebooks>`, which provide a hands-on introduction to the usage of the libraries modules while also explaining some of the theoretical concepts involved. Furthermore, an :doc:`API reference <api>` is provided.
+
+Contents
+~~~~~~~~
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,17 +30,14 @@ Quick Start
 Explainers
 ~~~~~~~~~~
 
-Here's a short example showing how to explain the prediction of a weighted :math:`k`-nearest neighbors model:
-
-..
-    TODO: Make sure all code blocks are ready to be copied and executed (don't contain any '...' in the instructions etc.)
+Here's a short example showing how to use `KNNExplainer` to explain the prediction of a weighted `KNeighborsClassifier`:
 
 .. code-block:: python
 
-    >>> from sklearn.neighbors import KNeighborsClassifier
     >>> from sklearn.datasets import make_classification
-    >>> from shapiq_student.explainer.knn import KNNExplainer, interaction_values_to_array
     >>> from sklearn.model_selection import train_test_split
+    >>> from sklearn.neighbors import KNeighborsClassifier
+    >>> from shapiq_student.explainer.knn import KNNExplainer, interaction_values_to_array
     >>>
     >>> X, y = make_classification(n_samples=40)
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -112,3 +112,5 @@ This example uses the ``GaussianImputer`` to explain the prediction of a random 
             (1, 6): 0.3318342718849081
             # ... more interactions
     )
+
+*(The outputs in the examples above have been truncated for readability.)*

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,15 +13,46 @@ It adds the following functionalities:
 2. **Imputers:** Provides a *Gaussian* imputer for background data with normally distributed features, and its extension, the *Gaussian copula* imputer, suitable for arbitrary, non-normally distributed data
 3. **Coalition Finding:** Implements an efficient, heuristic algorithm for finding maximal and minimal coalitions for a (simplified) game
 
-The best way to get started is by following one of the :doc:`notebooks <notebooks>`, which provide a hands-on introduction to the usage of the library's modules while also explaining some of the theoretical concepts involved. Furthermore, an :doc:`API reference <api>` is provided.
+To get a short overview of the library's features, have a look at the :ref:`quick start <quick-start>` below.
+For a more in-depth tutorial, follow one of the :doc:`notebooks <notebooks>`. They provide a hands-on introduction to the usage of the library's modules while also explaining some of the theoretical concepts involved.
+Details about the library's interfaces can be found in the :doc:`API reference <api>`.
 
 .. warning::
     The ``Explainer``\ s implemented here rely on undocumented implementation details of ``scikit-learn`` for extracting training data from the model they explain.
     As a result, compatibility is not guaranteed across versions, and these implementations may break with future updates of ``scikit-learn``.
     The functionality has been tested and is confirmed to work only for ``scikit-learn==1.7.0``.
 
+.. _quick-start:
+
+Quick Start
+-----------
+
+Here's a short example showing how to explain the prediction of a weighted :math:`k`-nearest neighbors model:
+
+.. code-block:: python
+
+   >>> from sklearn.neighbors import KNeighborsClassifier
+   >>> from shapiq_student.explainer.knn import KNNExplainer, interaction_values_to_array
+   >>>
+   >>> X_train, X_test, y_train, y_test = ...  # Load some data set
+   >>> # Created a weighted classifier using `weights="distance"`
+   >>> model = KNeighborsClassifier(n_neighbors=7, weights="distance")
+   >>> model.fit(X_train, y_train)
+   >>>
+   >>> # Explain the prediction for class 0
+   >>> explainer = KNNExplainer(model, class_index=0)
+   >>> type(explainer)  # Explainer for weighted KNN models was selected automatically
+   <class 'shapiq_student.explainer.knn.weighted_knn.WeightedKNNExplainer'>
+   >>>
+   >>> iv = explainer.explain(X_test[0])
+   >>> sv = interaction_values_to_array(iv)  # Convert to array for easier handling
+   >>> sv
+   array([ 0.04347826, -0.00197628,  0.07894378, ... ])
+   >>> sv.shape[0] == X_train.shape[0]  # Every training data point is assigned a Shapley Value
+   True
+
 Contents
-~~~~~~~~
+--------
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ Quick Start
 Explainers
 ~~~~~~~~~~
 
-Here's a short example showing how to use `KNNExplainer` to explain the prediction of a weighted `KNeighborsClassifier`:
+Here's a short example showing how to use ``KNNExplainer`` to explain the prediction of a weighted ``KNeighborsClassifier``:
 
 .. code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,7 +98,7 @@ This example uses the ``GaussianImputer`` to explain the prediction of a random 
     >>> model.fit(X_train, y_train)
     RandomForestRegressor(...)
     >>>
-    >>> gaussian_imputer = GaussianImputer(model=model.predict, data=X_train, n_mc_samples=100)
+    >>> gaussian_imputer = GaussianImputer(model=model.predict, data=X_train, n_mc_samples=1000)
     >>> explainer = TabularExplainer(
     ...     model=model, data=X_train, index="SII", max_order=2, imputer=gaussian_imputer
     ... )

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ The ``shapiq_student`` Python package
 The ``shapiq_student`` package is an extension to the the ``shapiq`` library for approximating Shapley interactions and explaining machine learning models.
 It adds the following functionalities:
 
-1. **Explainers:** Easy-to-use explainers implementing efficient algorithms for explaining nearest neighbor models, including unweighted and weighted $k$-nearest neighbor classifiers, as well as threshold nearest neighbor classifiers.
+1. **Explainers:** Easy-to-use explainers implementing efficient algorithms for explaining nearest neighbor models, including unweighted and weighted $k$-nearest neighbor classifiers, as well as threshold nearest neighbor classifiers
 2. **Imputers:** Provides a *Gaussian* imputer for background data with normally distributed features, and its extension, the *Gaussian copula* imputer, suitable for arbitrary, non-normally distributed data
 3. **Coalition Finding:** Implements an efficient, heuristic algorithm for finding maximal and minimal coalitions for a (simplified) game
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,9 @@ Details about the library's interfaces can be found in the :doc:`API reference <
 Quick Start
 -----------
 
+Explainers
+~~~~~~~~~~
+
 Here's a short example showing how to explain the prediction of a weighted :math:`k`-nearest neighbors model:
 
 .. code-block:: python
@@ -50,6 +53,11 @@ Here's a short example showing how to explain the prediction of a weighted :math
    array([ 0.04347826, -0.00197628,  0.07894378, ... ])
    >>> sv.shape[0] == X_train.shape[0]  # Every training data point is assigned a Shapley Value
    True
+
+Imputers
+~~~~~~~~
+
+The following example uses the `GaussianImputer` to explain the prediction of a random forest model.
 
 Contents
 --------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,7 +57,43 @@ Here's a short example showing how to explain the prediction of a weighted :math
 Imputers
 ~~~~~~~~
 
-The following example uses the `GaussianImputer` to explain the prediction of a random forest model.
+This example uses the ``GaussianImputer`` to explain the prediction of a random forest model trained on the California Housing dataset.
+
+.. code-block:: python
+
+    >>> from shapiq.datasets import load_california_housing
+    >>> from sklearn.ensemble import RandomForestRegressor
+    >>> from sklearn.model_selection import train_test_split
+    >>>
+    >>> from shapiq import TabularExplainer
+    >>> from shapiq_student import GaussianImputer
+    >>>
+    >>> X, y = load_california_housing()
+    >>> X_train, X_test, y_train, y_test = train_test_split(
+    ...     X.values,
+    ...     y.values,
+    ...     test_size=0.25,
+    ...     random_state=42,
+    ... )
+    >>> model = RandomForestRegressor(
+    ...     max_depth=X_train.shape[1], max_features=2 / 3, max_samples=2 / 3, random_state=42,
+    ... )
+    >>> model.fit(X_train, y_train)
+    RandomForestRegressor(...)
+    >>> gaussian_imputer = GaussianImputer(model=model.predict, data=X_train, n_mc_samples=100)
+    >>> explainer = TabularExplainer(
+    ...     model=model, data=X_train, index="SII", max_order=2, imputer=gaussian_imputer
+    ... )
+    >>> explainer.explain(X_test[0], budget=2**X_train.shape[1])
+    InteractionValues(
+        index=SII, max_order=2, min_order=0, estimated=False, estimation_budget=256,
+        n_players=8, baseline_value=0.0,
+        Top 10 interactions:
+            (): 1.5283145711993955
+            (4, 7): 0.3442686728461907
+            (1, 6): 0.3318342718849081
+            # ... more interactions
+    )
 
 Contents
 --------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ The ``shapiq_student`` package is an extension to the ``shapiq`` library for exp
 It adds the following functionalities:
 
 1. **Explainers:** Easy-to-use explainers implementing efficient algorithms for explaining nearest neighbor models, including unweighted and weighted $k$-nearest neighbor classifiers, as well as threshold nearest neighbor classifiers
-2. **Imputers:** Provides a *Gaussian* imputer for background data with normally distributed features, and its extension, the *Gaussian copula* imputer, suitable for arbitrary, non-normally distributed data
+2. **Imputers:** Offers a *Gaussian* imputer for normally distributed features, plus a *Gaussian copula* variant that accommodates multivariate dependencies when marginals deviate from normality.
 3. **Coalition Finding:** Implements an efficient, heuristic algorithm for finding maximal and minimal coalitions for a (simplified) game
 
 To get a short overview of the library's features, have a look at the :ref:`quick start <quick-start>` below.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ It adds the following functionalities:
 2. **Imputers:** Provides a *Gaussian* imputer for background data with normally distributed features, and its extension, the *Gaussian copula* imputer, suitable for arbitrary, non-normally distributed data
 3. **Coalition Finding:** Implements an efficient, heuristic algorithm for finding maximal and minimal coalitions for a (simplified) game
 
-The best way to get started is by following one of the :doc:`notebooks <notebooks>`, which provide a hands-on introduction to the usage of the libraries modules while also explaining some of the theoretical concepts involved. Furthermore, an :doc:`API reference <api>` is provided.
+The best way to get started is by following one of the :doc:`notebooks <notebooks>`, which provide a hands-on introduction to the usage of the library's modules while also explaining some of the theoretical concepts involved. Furthermore, an :doc:`API reference <api>` is provided.
 
 Contents
 ~~~~~~~~

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,7 +68,7 @@ Here's a short example showing how to use ``KNNExplainer`` to explain the predic
     >>> sv = interaction_values_to_array(iv)  # Convert to array for easier handling
     >>> sv
     array([ 0.06971687,  0.03333333,  0.09914777, ... ])
-    >>> sv.shape[0] == X_train.shape[0]  # Every training data point is assigned a Shapley Value
+    >>> sv.shape[0] == X_train.shape[0]  # Every training data point is assigned a Shapley value
     True
 
 Imputers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ docs = [
     "furo>=2024.8.6",
     "nbsphinx>=0.9.7",
     "sphinx>=8.1.3",
+    "sphinx-copybutton>=0.5.2",
 ]
 dev = [
     "build>=1.2.2.post1",

--- a/uv.lock
+++ b/uv.lock
@@ -2895,12 +2895,14 @@ dev = [
     { name = "scipy-stubs", version = "1.15.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy-stubs", version = "1.16.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx" },
+    { name = "sphinx-copybutton" },
     { name = "twine" },
 ]
 docs = [
     { name = "furo" },
     { name = "nbsphinx" },
     { name = "sphinx" },
+    { name = "sphinx-copybutton" },
 ]
 lint = [
     { name = "pre-commit" },
@@ -2942,12 +2944,14 @@ dev = [
     { name = "scikit-learn", specifier = ">=1.6.1" },
     { name = "scipy-stubs", specifier = ">=1.15.3.0" },
     { name = "sphinx", specifier = ">=8.1.3" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "twine", specifier = ">=6.1.0" },
 ]
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "nbsphinx", specifier = ">=0.9.7" },
     { name = "sphinx", specifier = ">=8.1.3" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
 ]
 lint = [
     { name = "pre-commit", specifier = ">=4.2.0" },
@@ -3056,6 +3060,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds an introductory text to the documentation landing page that
- gives an overview about the features of the library
- has a table of contents of the documentation
- contains a 'Quick Start' section with two short code examples for impatient users