### PR TITLE
Remove unused members from `KNNExplainerBase`

### DIFF
--- a/shapiq_student/explainer/knn/_common_knn.py
+++ b/shapiq_student/explainer/knn/_common_knn.py
@@ -57,7 +57,7 @@ class _CommonKNNExplainer(KNNExplainer):
         # The type of the superclass's `model` attribute is to broad, since it also allows for other KNN explainers
         # To circumvent this, we store the model separately in an attribute with a narrower type
         self.knn_model = model
-        self.k = self.knn_model.n_neighbors  # type: ignore[attr-defined]
+        self.k: int = self.knn_model.n_neighbors  # type: ignore[attr-defined]
 
 
 def get_knn_explainer_class(

--- a/shapiq_student/explainer/knn/base.py
+++ b/shapiq_student/explainer/knn/base.py
@@ -45,9 +45,6 @@ class KNNExplainer(Explainer):
     y_train: npt.NDArray[np.object_]
     """Training data labels extracted from the model. This array simply resolves the indirection of looking up class indices from ``y_train_indices`` in ``y_train_classes``."""
 
-    k: int
-    """The parameter ``k`` of the k-nearest neighbors model."""
-
     def __init__(
         self,
         model: KNeighborsClassifier | RadiusNeighborsClassifier,

--- a/shapiq_student/explainer/knn/base.py
+++ b/shapiq_student/explainer/knn/base.py
@@ -42,9 +42,6 @@ class KNNExplainer(Explainer):
     y_train_classes: npt.NDArray[np.object_]
     """Classes that appear in the model's training data."""
 
-    y_train: npt.NDArray[np.object_]
-    """Training data labels extracted from the model. This array simply resolves the indirection of looking up class indices from ``y_train_indices`` in ``y_train_classes``."""
-
     def __init__(
         self,
         model: KNeighborsClassifier | RadiusNeighborsClassifier,
@@ -100,7 +97,6 @@ class KNNExplainer(Explainer):
         if self.y_train_indices.ndim != 1:
             raise MultiOutputKNNError
         self.y_train_classes = cast("npt.NDArray[np.object_]", model.classes_)
-        self.y_train = self.y_train_classes[self.y_train_indices]
 
         # This is highly sketchy. We are relying on `shapiq` to handle `class_index == None` analogously, but there is no way to check, since they don't set `class_index` as an attribute of `shapiq.Explainer`
         if class_index is None:

--- a/tests/tests_knn_explainer/test_base.py
+++ b/tests/tests_knn_explainer/test_base.py
@@ -35,9 +35,8 @@ def test_extract_training_data_from_model():
     knn_explainer = KNNExplainer(knn_model, class_index=class_index)
 
     assert np.allclose(knn_explainer.X_train, X_train)
-    assert np.allclose(knn_explainer.y_train, y_train)
+    assert np.allclose(knn_explainer.y_train_classes[knn_explainer.y_train_indices], y_train)
     assert set(knn_explainer.y_train_classes) == set(y_train)
-    assert knn_explainer.k == k
     assert knn_explainer.class_index == class_index
 
 

--- a/tests/tests_knn_explainer/test_threshold_nn.py
+++ b/tests/tests_knn_explainer/test_threshold_nn.py
@@ -31,7 +31,7 @@ class TestThresholdNNExplainer:
         tnn_explainer = ThresholdNNExplainer(radius_model, class_index=class_index)
 
         assert np.allclose(tnn_explainer.X_train, X_train)
-        assert np.allclose(tnn_explainer.y_train, y_train)
+        assert np.allclose(tnn_explainer.y_train_classes[tnn_explainer.y_train_indices], y_train)
         assert tnn_explainer.tau == tau
         assert set(tnn_explainer.y_train_classes) == set(y_train)
         assert tnn_explainer.class_index == class_index


### PR DESCRIPTION
This PR removes the unused members `k` and `y_train` from the `KNNExplainerBase` class