### PR TITLE
Unify terminology

### DIFF
--- a/docs/source/notebooks/explainers_1.ipynb
+++ b/docs/source/notebooks/explainers_1.ipynb
@@ -122,7 +122,7 @@
    "source": [
     "Note that we set `class_index=y_explain_pred`, since for now, we want to quantify the contribution of the training data to the class that was actually predicted. (We could also set a different class index if we wished to see how much the data points contribute to shifting the prediction towards another class.)\n",
     "\n",
-    "In order to obtain an explanation, we simply call the `explain()` method of the explainer with the test datapoint. This will return an `InteractionValues` object containing the Shapley Values for each datapoint in the training data set."
+    "In order to obtain an explanation, we simply call the `explain()` method of the explainer with the test datapoint. This will return an `InteractionValues` object containing the Shapley values for each datapoint in the training data set."
    ]
   },
   {
@@ -139,7 +139,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `explain()` method implements the algorithm proposed in [\\[Jia19\\]](../citations.rst) for calculating Shapley Values for unweighted $k$-nearest neighbor models in **log-linear time**. To do so, it inspects the training data of the `sklearn` model that was passed in the constructor, sorts the training data points by their distance to $x_\\text{test}$ and finally computes Shapley Values in linear time.\n",
+    "The `explain()` method implements the algorithm proposed in [\\[Jia19\\]](../citations.rst) for calculating Shapley values for unweighted $k$-nearest neighbor models in **log-linear time**. To do so, it inspects the training data of the `sklearn` model that was passed in the constructor, sorts the training data points by their distance to $x_\\text{test}$ and finally computes Shapley values in linear time.\n",
     "\n",
     "For easier handling we can convert the `InteractionValues` object to a simple numpy array, since we only have interactions of order 1. To do so, we use a utility function provided by `shapiq_student`,"
    ]
@@ -160,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we sum up all Shapley Values, we should get our original model prediction for class index `0`, which was 66%:"
+    "If we sum up all Shapley values, we should get our original model prediction for class index `0`, which was 66%:"
    ]
   },
   {
@@ -212,7 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is still not very helpful, so let's visualize the Shapley Values by plotting the training data set again, this time setting the size of each dot according to the Shapley Value attributed to the training data point it represents. The `shapiq_student` library provides the function `plot_points_shapley_2d` for just this purpose."
+    "This is still not very helpful, so let's visualize the Shapley values by plotting the training data set again, this time setting the size of each dot according to the Shapley value attributed to the training data point it represents. The `shapiq_student` library provides the function `plot_points_shapley_2d` for just this purpose."
    ]
   },
   {
@@ -233,10 +233,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The plot represents each training data point as a circle colored according to its class and scaled by its absolute Shapley Value. Positive values are shown as filled circles and negative values as empty circles.\n",
+    "The plot represents each training data point as a circle colored according to its class and scaled by its absolute Shapley value. Positive values are shown as filled circles and negative values as empty circles.\n",
     "\n",
-    "As we can observe, training data points whose class agrees with `class_index` have positive Shapley Values while the rest have negative Shapley Values.\n",
-    "Furthermore, points that are closer to the explanation point $x_\\text{explain}$ have higher absolute Shapley Values than the ones farther away. This makes sense, since the points closest to $x_\\text{explain}$ have the highest chance of being among the $k$-nearest points, thereby influencing the prediction of the model, while points farther away can rarely change the prediction."
+    "As we can observe, training data points whose class agrees with `class_index` have positive Shapley values while the rest have negative Shapley values.\n",
+    "Furthermore, points that are closer to the explanation point $x_\\text{explain}$ have higher absolute Shapley values than the ones farther away. This makes sense, since the points closest to $x_\\text{explain}$ have the highest chance of being among the $k$-nearest points, thereby influencing the prediction of the model, while points farther away can rarely change the prediction."
    ]
   },
   {
@@ -245,9 +245,9 @@
    "source": [
     "## Data Valuation for KNN\n",
     "\n",
-    "In the context of data valuation, we want to quantify the usefulness of training data to a model's performance. Shapley Values provide a simple way to achieve this goal. To estimate the usefulness of each point of a training data set, we calculate Shapley Values for a set of test data points and average the results.\n",
+    "In the context of data valuation, we want to quantify the usefulness of training data to a model's performance. Shapley values provide a simple way to achieve this goal. To estimate the usefulness of each point of a training data set, we calculate Shapley values for a set of test data points and average the results.\n",
     "\n",
-    "First, let's create a classification data set and split it into train and test sets. We will corrupt the training data by changing the class of a few randomly selected data points. Later, we will observe how we can identify corrupted or useless training data with Shapley Values."
+    "First, let's create a classification data set and split it into train and test sets. We will corrupt the training data by changing the class of a few randomly selected data points. Later, we will observe how we can identify corrupted or useless training data with Shapley values."
    ]
   },
   {
@@ -296,7 +296,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's compute Shapley Values based on the entire test dataset by averaging the Shapley Values computed using each test point."
+    "Now, let's compute Shapley values based on the entire test dataset by averaging the Shapley values computed using each test point."
    ]
   },
   {
@@ -324,7 +324,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can reasonably assume that the corrupted training data points will on average make the model's prediction worse, resulting in negative Shapley Values. So let's filter out just those indices where the Shapley Value is below zero and compare with our original array of corrupted indices:"
+    "We can reasonably assume that the corrupted training data points will on average make the model's prediction worse, resulting in negative Shapley values. So let's filter out just those indices where the Shapley value is below zero and compare with our original array of corrupted indices:"
    ]
   },
   {
@@ -334,7 +334,7 @@
    "outputs": [],
    "source": [
     "print(f\"Corrupted: {np.sort(corrupted)}\")  # Sort for easier comparison\n",
-    "print(f\"Negative Shapley Values: {np.where(sv_test < 0)[0]}\")"
+    "print(f\"Negative Shapley values: {np.where(sv_test < 0)[0]}\")"
    ]
   },
   {
@@ -361,7 +361,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we look closely at how the test dataset is distributed, we can observe that no test point is close to $x_{20}$, and more importantly there are a lot of 'correct' training data points between $x_{20}$ and the closest test data points. This means that it rarely got to influence the model prediction at all, which may explain why its Shapley Value didn't get shifted much toward the negative.\n",
+    "If we look closely at how the test dataset is distributed, we can observe that no test point is close to $x_{20}$, and more importantly there are a lot of 'correct' training data points between $x_{20}$ and the closest test data points. This means that it rarely got to influence the model prediction at all, which may explain why its Shapley value didn't get shifted much toward the negative.\n",
     "\n",
     "## Up next\n",
     "\n",

--- a/docs/source/notebooks/explainers_1.ipynb
+++ b/docs/source/notebooks/explainers_1.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Explaining Nearest-Neighbor Classifiers: Introduction\n",
+    "# Explaining Nearest Neighbor Classifiers: Introduction\n",
     "\n",
-    "When explaining nearest-neighbor classifiers, the goal is, given a model trained on some training dataset $D$, to quantify how much each training data point $z_i = (x_i, y_i) \\in D$ contributes to the model predicting the 'explanation class' $y_\\text{explain}$ on some explanation point $x_\\text{explain}$. For this purpose we can define, in the case of a simple $k$-nearest neighbors classifier, the utility of a coalition $S \\subseteq D$ as the likelihood of predicting the class $y_\\text{explain}$ [\\[Jia19\\]](../citations.rst):\n",
+    "When explaining nearest neighbor classifiers, the goal is, given a model trained on some training dataset $D$, to quantify how much each training data point $z_i = (x_i, y_i) \\in D$ contributes to the model predicting the 'explanation class' $y_\\text{explain}$ on some explanation point $x_\\text{explain}$. For this purpose we can define, in the case of a simple $k$-nearest neighbors classifier, the utility of a coalition $S \\subseteq D$ as the likelihood of predicting the class $y_\\text{explain}$ [\\[Jia19\\]](../citations.rst):\n",
     "$$\n",
     "    \\nu(S) = \\frac{1}{k} \\sum_{j=1}^{\\min\\{k, |S|\\}} \\chi(y_{\\alpha_{S,j}} = y_\\text{explain}),\n",
     "$$\n",
@@ -20,9 +20,9 @@
     "    \\right.\n",
     "$$\n",
     "\n",
-    "While `shapiq` already offers a way to explain nearest-neighbor models using `ExactComputer`, it requires evaluating the utility function for all possible coalitions, resulting in an exponential runtime. However, special properties of nearest-neighbor models can be exploited for designing more efficient algorithms, which are implemented in this library.\n",
+    "While `shapiq` already offers a way to explain nearest neighbor models using `ExactComputer`, it requires evaluating the utility function for all possible coalitions, resulting in an exponential runtime. However, special properties of nearest-neighbor models can be exploited for designing more efficient algorithms, which are implemented in this library.\n",
     "\n",
-    "Here is an overview of the three kinds of nearest-neighbor classifiers for which `shapiq_student` implements explainers:\n",
+    "Here is an overview of the three kinds of nearest neighbor classifiers for which `shapiq_student` implements explainers:\n",
     "\n",
     "| Classifier | `sklearn` implementation | Basis for explanation algorithm |\n",
     "|---|---|---|\n",
@@ -32,7 +32,7 @@
     "\n",
     "For this notebook, we will limit ourselves to the simplest option, the unweighted $k$-nearest neighbors (KNN) classifier. The other two kinds of classifiers are discussed in the [follow-up notebook](./explainers_2.ipynb).\n",
     "\n",
-    "Let's start with some setup. First, we generate a synthetic classification dataset with some non-linearity, making it suitable for nearest-neighbor classification. The dataset has two classes and just two features to simplify the presentation. We will plot the dataset using the function `plot_datasets`, which we defined in a separate file since we don't want to bore you with the details."
+    "Let's start with some setup. First, we generate a synthetic classification dataset with some non-linearity, making it suitable for nearest neighbor classification. The dataset has two classes and just two features to simplify the presentation. We will plot the dataset using the function `plot_datasets`, which we defined in a separate file since we don't want to bore you with the details."
    ]
   },
   {

--- a/docs/source/notebooks/explainers_2.ipynb
+++ b/docs/source/notebooks/explainers_2.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Explaining Nearest-Neighbor Classifiers: Weighted and Thresholded Classifiers\n",
+    "# Explaining Nearest Neighbor Classifiers: Weighted and Thresholded Classifiers\n",
     "\n",
     "In the [previous notebook](explainers_1.ipynb) we only considered unweighted $k$-nearest neighbor classifiers.\n",
     "Next, let's focus on the slightly more advanced _weighted_ $k$-nearest neighbor classifier.\n",

--- a/docs/source/notebooks/explainers_2.ipynb
+++ b/docs/source/notebooks/explainers_2.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "where $\\alpha_j$ is the index of the $j$-nearest training data point to $x$. The advantage of WKNN is that it is generally more accurate since it's better at handling varying densities in the training data, distant but numerically dominant classes, as well as noise.\n",
     "\n",
-    "Next, we will discuss how to design a utility function for efficiently calculating Shapley Values for WKNN models. If you're only interested in the actual code, you can of course skip this section and jump right into [explaining WKNN predictions](#explaining-wknn-predictions)."
+    "Next, we will discuss how to design a utility function for efficiently calculating Shapley values for WKNN models. If you're only interested in the actual code, you can of course skip this section and jump right into [explaining WKNN predictions](#explaining-wknn-predictions)."
    ]
   },
   {
@@ -31,7 +31,7 @@
    "source": [
     "### Making WKNN Shapley-friendly\n",
     "\n",
-    "In order to make WKNN models more suitable for efficiently computing Shapley Values, some adjustments are made compared to unweighted KNN models [\\[Wng24\\]](../citations.rst):\n",
+    "In order to make WKNN models more suitable for efficiently computing Shapley values, some adjustments are made compared to unweighted KNN models [\\[Wng24\\]](../citations.rst):\n",
     "\n",
     "- The task of explaining a prediction $y_\\text{explain}$ for a multi-class model is reduced to combining the explanations for the binary prediction of '$y_\\text{explain}$ versus $c$' for all $c \\neq y_\\text{train}$:\n",
     "  $$\n",
@@ -192,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Looking good! Close points with the predicted class have large positive Shapley Values, while close points with a different class have large negative values. Points farther away have values close to zero, meaning they barely influenced the prediction.\n",
+    "Looking good! Close points with the predicted class have large positive Shapley values, while close points with a different class have large negative values. Points farther away have values close to zero, meaning they barely influenced the prediction.\n",
     "\n",
     "Next, let's move on to threshold nearest neighbor models."
    ]
@@ -292,7 +292,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see, a large portion of the Shapley Values is zero. To understand what this means, let's plot them like before. Additionally, we'll mark the radius $\\tau$ of the TNN model in the plot."
+    "As we can see, a large portion of the Shapley values is zero. To understand what this means, let's plot them like before. Additionally, we'll mark the radius $\\tau$ of the TNN model in the plot."
    ]
   },
   {
@@ -320,7 +320,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we can see where all those zeros come from: All training data points outside of the $\\tau$-neighbourhood around $x_\\text{test}$ have zero Shapley Values. This is because they can't influence the prediction at all. (Note that in the plot, values of zero are represented as dots of size `0.1` since we set `min_size=0.1`. We do this so that they still remain visible.)\n",
+    "Here we can see where all those zeros come from: All training data points outside of the $\\tau$-neighbourhood around $x_\\text{test}$ have zero Shapley values. This is because they can't influence the prediction at all. (Note that in the plot, values of zero are represented as dots of size `0.1` since we set `min_size=0.1`. We do this so that they still remain visible.)\n",
     "\n",
     "That's it for this notebook! For detailed information on the API of the explainer classes, see the [API reference](../api/shapiq_student.explainer.rst)."
    ]

--- a/docs/source/notebooks/explainers_2.ipynb
+++ b/docs/source/notebooks/explainers_2.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Explaining Nearest Neighbor Classifiers: Weighted and Thresholded Classifiers\n",
+    "# Explaining Nearest Neighbor Classifiers: Weighted and Threshold Classifiers\n",
     "\n",
     "In the [previous notebook](explainers_1.ipynb) we only considered unweighted $k$-nearest neighbor classifiers.\n",
     "Next, let's focus on the slightly more advanced _weighted_ $k$-nearest neighbor classifier.\n",

--- a/shapiq_student/explainer/knn/base.py
+++ b/shapiq_student/explainer/knn/base.py
@@ -23,7 +23,7 @@ class KNNExplainer(Explainer):
 
     Based on the model passed to the constructor, the class automatically detects between
     :class:`~shapiq_student.explainer.knn.NormalKNNExplainer` and
-    :class:`~shapiq_student.explainer.knn.WeightedKNNExplainer` for (weighted) k-nearest neighbor models,
+    :class:`~shapiq_student.explainer.knn.WeightedKNNExplainer` for (weighted) :math:`k`-nearest neighbor models,
     as well as :class:`~shapiq_student.explainer.knn.ThresholdNNExplainer` for thresholded nearest neighbor models.
 
     For a detailed description of the different explainers, see the respective classes.

--- a/shapiq_student/explainer/knn/base.py
+++ b/shapiq_student/explainer/knn/base.py
@@ -130,13 +130,13 @@ def get_explainer_class(
 def interaction_values_from_array(
     shapley_values: npt.NDArray[np.floating],
 ) -> InteractionValues:
-    """Convert an array of Shapley Values to a ``shapiq.interaction_values.InteractionValues`` object.
+    """Convert an array of Shapley values to a ``shapiq.interaction_values.InteractionValues`` object.
 
     Args:
-        shapley_values: An ``np.ndarray`` containing the Shapley Value of the ith training point at index i.
+        shapley_values: An ``np.ndarray`` containing the Shapley value of the ith training point at index i.
 
     Returns:
-        An ``InteractionValues`` object containing the provided Shapley Values with an appropriate ``interaction_lookup`` dict and with ``min_order == max_order == 1`` set.
+        An ``InteractionValues`` object containing the provided Shapley values with an appropriate ``interaction_lookup`` dict and with ``min_order == max_order == 1`` set.
     """
     n_players = shapley_values.shape[0]
     interaction_lookup: dict[tuple[int, ...], int] = {(i,): i for i in range(n_players)}
@@ -155,7 +155,7 @@ def interaction_values_from_array(
 def interaction_values_to_array(
     interaction_values: InteractionValues,
 ) -> npt.NDArray[np.floating]:
-    """Extract an array of Shapley Values from a ``shapiq.interaction_values.InteractionValues`` object.
+    """Extract an array of Shapley values from a ``shapiq.interaction_values.InteractionValues`` object.
 
     Args:
         interaction_values: An InteractionValues object with ``max_order==1``

--- a/shapiq_student/explainer/knn/base.py
+++ b/shapiq_student/explainer/knn/base.py
@@ -24,7 +24,7 @@ class KNNExplainer(Explainer):
     Based on the model passed to the constructor, the class automatically detects between
     :class:`~shapiq_student.explainer.knn.NormalKNNExplainer` and
     :class:`~shapiq_student.explainer.knn.WeightedKNNExplainer` for (weighted) :math:`k`-nearest neighbor models,
-    as well as :class:`~shapiq_student.explainer.knn.ThresholdNNExplainer` for thresholded nearest neighbor models.
+    as well as :class:`~shapiq_student.explainer.knn.ThresholdNNExplainer` for threshold nearest neighbor models.
 
     For a detailed description of the different explainers, see the respective classes.
     """

--- a/shapiq_student/explainer/knn/normal_knn.py
+++ b/shapiq_student/explainer/knn/normal_knn.py
@@ -22,7 +22,7 @@ MODE_NORMAL = "normal"
 
 
 class _BruteForceNormalKNNExplainer(_CommonKNNExplainer):
-    """Brute force approach to computing Shapley Values for normal (unweighted) KNN models."""
+    """Brute force approach to computing Shapley values for normal (unweighted) KNN models."""
 
     @override
     def __init__(
@@ -64,7 +64,7 @@ class _BruteForceNormalKNNExplainer(_CommonKNNExplainer):
 class NormalKNNExplainer(_CommonKNNExplainer):
     r"""Explainer for unweighted KNN models.
 
-    Implements the algorithm proposed by `Jia et al. (2019)` [Jia19]_ to efficiently calculate Shapley Values for unweighted KNN models.
+    Implements the algorithm proposed by `Jia et al. (2019)` [Jia19]_ to efficiently calculate Shapley values for unweighted KNN models.
     The algorithm itself has a linear time complexity, but expects a sorted array of training points as input, resulting in a time complexity of :math:`O(N \log N)` for explaining a single data point.
     """
 

--- a/shapiq_student/explainer/knn/normal_knn.py
+++ b/shapiq_student/explainer/knn/normal_knn.py
@@ -64,7 +64,7 @@ class _BruteForceNormalKNNExplainer(_CommonKNNExplainer):
 class NormalKNNExplainer(_CommonKNNExplainer):
     r"""Explainer for unweighted KNN models.
 
-    Implements the algorithm proposed by `Jia et al. (2019)` [Jia19]_ to efficiently calculate Shapley values for unweighted KNN models.
+    Implements the algorithm proposed by Jia et al. (2019) [Jia19]_ to efficiently calculate Shapley values for unweighted KNN models.
     The algorithm itself has a linear time complexity, but expects a sorted array of training points as input, resulting in a time complexity of :math:`O(N \log N)` for explaining a single data point.
     """
 

--- a/shapiq_student/explainer/knn/threshold_nn.py
+++ b/shapiq_student/explainer/knn/threshold_nn.py
@@ -82,7 +82,7 @@ class _BruteForceTNNExplainer(KNNExplainer):
 class ThresholdNNExplainer(KNNExplainer):
     r"""Explainer for threshold nearest-neighbour models.
 
-    Implements the algorithm for efficiently computing exact Shapley Values for threshold nearest-neighbor models proposed by `Wang et. al (2023)` [Wng23]_.
+    Implements the algorithm for efficiently computing exact Shapley values for threshold nearest-neighbor models proposed by `Wang et. al (2023)` [Wng23]_.
     The algorithm has a runtime complexity of :math:`O(N)` (when explaining a single data point), where :math:`N` is the number of training samples.
     """
 

--- a/shapiq_student/explainer/knn/threshold_nn.py
+++ b/shapiq_student/explainer/knn/threshold_nn.py
@@ -78,7 +78,7 @@ class _BruteForceTNNExplainer(KNNExplainer):
 class ThresholdNNExplainer(KNNExplainer):
     r"""Explainer for threshold nearest-neighbour models.
 
-    Implements the algorithm for efficiently computing exact Shapley values for threshold nearest neighbor models proposed by `Wang et al. (2023)` [Wng23]_.
+    Implements the algorithm for efficiently computing exact Shapley values for threshold nearest neighbor models proposed by Wang et al. (2023) [Wng23]_.
     The algorithm has a runtime complexity of :math:`O(N)` (when explaining a single data point), where :math:`N` is the number of training samples.
     """
 
@@ -112,8 +112,8 @@ class ThresholdNNExplainer(KNNExplainer):
     @override
     def explain_function(self, x: npt.NDArray[np.floating]) -> InteractionValues:
         # Efficient sv computation
-        # Following Theorem 17 and equation (7) (Wang et al. (2023) DOI: 2308.15709v2)
-        # Counting queries defined in C2.2 (by Wang et al. (2023) DOI: 2308.15709v2)
+        # Following Theorem 17 and equation (7) in Wang et al. (2023) DOI: 2308.15709v2
+        # Counting queries defined in C2.2 ibid.
         n_train = self.X_train.shape[0]
         n_classes = self.y_train_indices.shape[0]
 

--- a/shapiq_student/explainer/knn/threshold_nn.py
+++ b/shapiq_student/explainer/knn/threshold_nn.py
@@ -60,7 +60,7 @@ class _BruteForceTNNExplainer(KNNExplainer):
 
             n_coal_nhood = np.sum(coal_nhood)
 
-            # Utility function according to equation (3) in paper by Wang et. al (2023) DOI: 2308.15709v2
+            # Utility function according to equation (3) in paper by Wang et al. (2023) DOI: 2308.15709v2
             if n_coal_nhood == 0:
                 utility = 1 / n_classes
             else:
@@ -78,7 +78,7 @@ class _BruteForceTNNExplainer(KNNExplainer):
 class ThresholdNNExplainer(KNNExplainer):
     r"""Explainer for threshold nearest-neighbour models.
 
-    Implements the algorithm for efficiently computing exact Shapley values for threshold nearest neighbor models proposed by `Wang et. al (2023)` [Wng23]_.
+    Implements the algorithm for efficiently computing exact Shapley values for threshold nearest neighbor models proposed by `Wang et al. (2023)` [Wng23]_.
     The algorithm has a runtime complexity of :math:`O(N)` (when explaining a single data point), where :math:`N` is the number of training samples.
     """
 
@@ -112,8 +112,8 @@ class ThresholdNNExplainer(KNNExplainer):
     @override
     def explain_function(self, x: npt.NDArray[np.floating]) -> InteractionValues:
         # Efficient sv computation
-        # Following Theorem 17 and equation (7) (Wang et. al (2023) DOI: 2308.15709v2)
-        # Counting queries defined in C2.2 (by Wang et. al (2023) DOI: 2308.15709v2)
+        # Following Theorem 17 and equation (7) (Wang et al. (2023) DOI: 2308.15709v2)
+        # Counting queries defined in C2.2 (by Wang et al. (2023) DOI: 2308.15709v2)
         n_train = self.X_train.shape[0]
         n_classes = self.y_train_indices.shape[0]
 

--- a/shapiq_student/explainer/knn/threshold_nn.py
+++ b/shapiq_student/explainer/knn/threshold_nn.py
@@ -82,7 +82,7 @@ class _BruteForceTNNExplainer(KNNExplainer):
 class ThresholdNNExplainer(KNNExplainer):
     r"""Explainer for threshold nearest-neighbour models.
 
-    Implements the algorithm for efficiently computing exact Shapley values for threshold nearest-neighbor models proposed by `Wang et. al (2023)` [Wng23]_.
+    Implements the algorithm for efficiently computing exact Shapley values for threshold nearest neighbor models proposed by `Wang et. al (2023)` [Wng23]_.
     The algorithm has a runtime complexity of :math:`O(N)` (when explaining a single data point), where :math:`N` is the number of training samples.
     """
 

--- a/shapiq_student/explainer/knn/threshold_nn.py
+++ b/shapiq_student/explainer/knn/threshold_nn.py
@@ -1,4 +1,4 @@
-"""TKNN Classifier Explainer."""
+"""Implements the Explainer for threshold nearest neighbor models."""
 
 from __future__ import annotations
 
@@ -24,17 +24,13 @@ MODE_THRESHOLD = "threshold"
 
 
 class _BruteForceTNNExplainer(KNNExplainer):
-    """Brute force approach for explaining TKNN Classifiers.
-
-    References:
-        Based on the paper by Wang et. al (2023) DOI: 2308.15709v2.
-    """
+    """Brute force approach for explaining TNN Classifiers."""
 
     def __init__(self, model: RadiusNeighborsClassifier, class_index: int | None = None) -> None:
         super().__init__(model, class_index=class_index)
         # The type of the superclass's `model` attribute is too broad, since it also allows for other KNN explainers
         # To circumvent this, we store the model separately in an attribute with a narrower type
-        self.tknn_model = model
+        self.tnn_model = model
         self.tau = cast("float", model.radius)  # type: ignore[attr-defined]
 
     @property
@@ -47,7 +43,7 @@ class _BruteForceTNNExplainer(KNNExplainer):
         n_train = self.X_train.shape[0]
         n_classes = len(self.y_train_indices)
 
-        neighbor_indices = self.tknn_model.radius_neighbors(x.reshape(1, -1), return_distance=False)
+        neighbor_indices = self.tnn_model.radius_neighbors(x.reshape(1, -1), return_distance=False)
         neighbor_indices = neighbor_indices[0]
         in_neighborhood = np.zeros((n_train,), dtype=bool)
         in_neighborhood[neighbor_indices] = True

--- a/shapiq_student/explainer/knn/threshold_nn.py
+++ b/shapiq_student/explainer/knn/threshold_nn.py
@@ -106,7 +106,7 @@ class ThresholdNNExplainer(KNNExplainer):
     @property
     @override
     def mode(self) -> str:
-        """This explainer's mode, which is ``"treshold"``."""
+        """This explainer's mode, which is ``"threshold"``."""
         return MODE_THRESHOLD
 
     @override

--- a/shapiq_student/explainer/knn/weighted_knn.py
+++ b/shapiq_student/explainer/knn/weighted_knn.py
@@ -195,7 +195,7 @@ def _greater_or_close(a: np.floating, b: np.floating) -> np.bool:
 class WeightedKNNExplainer(_WeightedKNNExplainerBase):
     r"""Explainer for weighted KNN models.
 
-    Implements the algorithm for efficiently computing exact Shapley values for weighted KNN models proposed by `Wang et. al (2024)` [Wng24]_.
+    Implements the algorithm for efficiently computing exact Shapley values for weighted KNN models proposed by `Wang et al. (2024)` [Wng24]_.
     The algorithm achieves a runtime complexity of :math:`O\bigl(\frac{k^2 N^2 W}{C}\bigr)`, where
 
     * :math:`k` is the defining hyperparameter of the :math:`k`-nearest neighbors model,

--- a/shapiq_student/explainer/knn/weighted_knn.py
+++ b/shapiq_student/explainer/knn/weighted_knn.py
@@ -74,7 +74,7 @@ class _WeightedKNNExplainerBase(_CommonKNNExplainer):
 
 
 class _BruteForceWKNNExplainer(_WeightedKNNExplainerBase):
-    """A brute force implementation of WKNN Shapley Values.
+    """A brute force algorithm for computing WKNN Shapley values.
 
     References:
         .. [Wng24] Wang, Jiachen T., Prateek Mittal, and Ruoxi Jia. "Efficient data shapley for weighted nearest neighbor algorithms." International Conference on Artificial Intelligence and Statistics. PMLR, 2024.
@@ -127,7 +127,7 @@ class _BruteForceWKNNExplainer(_WeightedKNNExplainerBase):
         sortperm: npt.NDArray[np.integer],
         weights: npt.NDArray[np.floating],
     ) -> npt.NDArray[np.floating]:
-        """Computes the Shapley Values for a single binary-class classification game.
+        """Computes the Shapley values for a single binary-class classification game.
 
         Only training data points which have class index ``y_val`` or ``y_other`` are considered and all others ignored.
 
@@ -138,7 +138,7 @@ class _BruteForceWKNNExplainer(_WeightedKNNExplainerBase):
             weights: Array of weights assigned to each training data point.
 
         Returns:
-            An ``np.ndarray`` of Shapley Values for each training data point.
+            An ``np.ndarray`` of Shapley values for each training data point.
         """
         if self.n_bits is not None:
             _wang_explainer = WeightedKNNExplainer(
@@ -195,7 +195,7 @@ def _greater_or_close(a: np.floating, b: np.floating) -> np.bool:
 class WeightedKNNExplainer(_WeightedKNNExplainerBase):
     r"""Explainer for weighted KNN models.
 
-    Implements the algorithm for efficiently computing exact Shapley Values for weighted KNN models proposed by `Wang et. al (2024)` [Wng24]_.
+    Implements the algorithm for efficiently computing exact Shapley values for weighted KNN models proposed by `Wang et. al (2024)` [Wng24]_.
     The algorithm achieves a runtime complexity of :math:`O\bigl(\frac{k^2 N^2 W}{C}\bigr)`, where
 
     * :math:`k` is the defining hyperparameter of the :math:`k`-nearest neighbors model,

--- a/shapiq_student/explainer/knn/weighted_knn.py
+++ b/shapiq_student/explainer/knn/weighted_knn.py
@@ -195,7 +195,7 @@ def _greater_or_close(a: np.floating, b: np.floating) -> np.bool:
 class WeightedKNNExplainer(_WeightedKNNExplainerBase):
     r"""Explainer for weighted KNN models.
 
-    Implements the algorithm for efficiently computing exact Shapley values for weighted KNN models proposed by `Wang et al. (2024)` [Wng24]_.
+    Implements the algorithm for efficiently computing exact Shapley values for weighted KNN models proposed by [Wng24]_.
     The algorithm achieves a runtime complexity of :math:`O\bigl(\frac{k^2 N^2 W}{C}\bigr)`, where
 
     * :math:`k` is the defining hyperparameter of the :math:`k`-nearest neighbors model,

--- a/shapiq_student/imputer/gaussian/exceptions.py
+++ b/shapiq_student/imputer/gaussian/exceptions.py
@@ -15,7 +15,7 @@ class CategoricalFeatureError(ValueError):
         feature_names = [f"f{i + 1}" for i in feature_indices]
         message = (
             f"The following are categorical features: {', '.join(feature_names)}. "
-            "Gaussian approach does not support categorical features."
+            "Gaussian imputation does not support categorical features."
         )
         super().__init__(message)
         self.feature_indices = feature_indices

--- a/shapiq_student/imputer/gaussian/gaussian_copula_imputer.py
+++ b/shapiq_student/imputer/gaussian/gaussian_copula_imputer.py
@@ -1,4 +1,4 @@
-"""Implements the Gaussian copula approach for imputation."""
+"""Implements the Gaussian copula-based approach for imputation."""
 
 from __future__ import annotations
 

--- a/shapiq_student/imputer/gaussian/gaussian_copula_imputer.py
+++ b/shapiq_student/imputer/gaussian/gaussian_copula_imputer.py
@@ -1,4 +1,4 @@
-"""Copula's approach for imputation in Shapley Value calculations."""
+"""Implements the Gaussian copula approach for imputation."""
 
 from __future__ import annotations
 

--- a/shapiq_student/imputer/gaussian/gaussian_imputer.py
+++ b/shapiq_student/imputer/gaussian/gaussian_imputer.py
@@ -1,9 +1,4 @@
-"""Gaussian approach for imputation in Shapley Value calculations.
-
-This module implements a Gaussian-based approach for generating samples in Shapley Value
-calculations. It uses multivariate normal distribution for sampling and handles
-continuous features only.
-"""
+"""Implements the Gaussian approach for imputation."""
 
 from __future__ import annotations
 

--- a/shapiq_student/imputer/gaussian/gaussian_imputer.py
+++ b/shapiq_student/imputer/gaussian/gaussian_imputer.py
@@ -1,4 +1,4 @@
-"""Implements the Gaussian approach for imputation."""
+"""Implements the Gaussian-based approach for imputation."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ MAX_UNIQUE_VALUES_FOR_CATEGORICAL = 2
 
 
 class GaussianImputer(ConditionalImputer):
-    r"""Implements a Gaussian-based approach for imputation.
+    r"""Implements the Gaussian-based approach for imputation.
 
     This approach assumes that the features of the background data form a multivariate Gaussian distribution.
     The missing values are imputed by drawing Monte Carlo samples from the conditional distribution given the values of the features present in a coalition.

--- a/shapiq_student/plot.py
+++ b/shapiq_student/plot.py
@@ -31,9 +31,9 @@ def plot_points_shapley_2d(  # noqa: C901
     show_max: bool = False,
     min_size: float = 1,
 ) -> None:
-    """Plot a Shapley Values for a 2D training data set using matplotlib.
+    """Plot a Shapley values for a 2D training data set using matplotlib.
 
-    This function visualizes training data points with their associated Shapley Values, and optionally a test data point.
+    This function visualizes training data points with their associated Shapley values, and optionally a test data point.
     Each training point is shown with a marker size proportional to its absolute Shapley
     value. Positive values are shown as a filled circle and non-positve values as an emtpy circle.
 
@@ -50,7 +50,7 @@ def plot_points_shapley_2d(  # noqa: C901
         max_abs: Allows orverriding the maximum value used for scaling the marker sizes. Defaults to ``np.max(np.abs(shapley_values))``.
         show_max: Draw a black ring around each marker, representing the maximum absolute value.
         min_size: The minimum size of the scaled markers. It's recommended to set this to a small positive value
-            to prevent the smallest Shapley Values from becoming zero-size dots. Defaults to ``1``.
+            to prevent the smallest Shapley values from becoming zero-size dots. Defaults to ``1``.
 
     Raises:
         ValueError: If all Shapley values are zero.

--- a/tests/tests_knn_explainer/test_threshold_nn.py
+++ b/tests/tests_knn_explainer/test_threshold_nn.py
@@ -101,9 +101,9 @@ class TestThresholdNNExplainer:
 
         for i in range(len(set(y_train))):
             tnn_explainer = ThresholdNNExplainer(radius_model, class_index=i)
-            tknn_sv = interaction_values_to_array(tnn_explainer.explain(x_val))
-            assert np.isclose(tknn_sv[0], tknn_sv[1])
-            assert np.isclose(tknn_sv[2], tknn_sv[3])
+            tnn_sv = interaction_values_to_array(tnn_explainer.explain(x_val))
+            assert np.isclose(tnn_sv[0], tnn_sv[1])
+            assert np.isclose(tnn_sv[2], tnn_sv[3])
 
     def test_one_different_label_neighbor_in_threshold(self):
         """Tests ThresholdNNExplainer behavior when one neighbor is within threshold tau and of different label.

--- a/tests/tests_knn_explainer/test_threshold_nn.py
+++ b/tests/tests_knn_explainer/test_threshold_nn.py
@@ -61,7 +61,7 @@ class TestThresholdNNExplainer:
 
         Not all shapley values should be zero.
 
-        The resulting Shapley Values should be 0.5 for exactly one player and zero for the other. Reference: Formula (7) in Wang et al. [Wng23]_.
+        The resulting Shapley values should be 0.5 for exactly one player and zero for the other. Reference: Formula (7) in Wang et al. [Wng23]_.
         """
         X_train = np.array([[1, 1, 1], [11, 11, 11]])
         y_train = np.array([0, 1])
@@ -91,7 +91,7 @@ class TestThresholdNNExplainer:
         assert np.allclose(sv_array_tnn, 0)
 
     def test_two_same_labels_have_same_sv(self):
-        """Tests that two same label training points within threshold have the same Shapley Value."""
+        """Tests that two same label training points within threshold have the same Shapley value."""
         X_train = np.array([[1, 2, 3], [4, 5, 6], [2, 3, 4], [5, 1, 6]])
         y_train = np.array([0, 0, 1, 1])
         tau = 10
@@ -108,7 +108,7 @@ class TestThresholdNNExplainer:
     def test_one_different_label_neighbor_in_threshold(self):
         """Tests ThresholdNNExplainer behavior when one neighbor is within threshold tau and of different label.
 
-        Not all Shapley Values should be zero.
+        Not all Shapley values should be zero.
 
         Result should be -0.5. Reference: Formula (7) in Wang et. al arXiv:2308.15709v2.
         """
@@ -141,7 +141,7 @@ class TestThresholdNNExplainer:
             assert np.any(sv != 0)
 
     def test_point_slightly_outside_threshold(self):
-        """Tests that training points slightly outside of the threshold will not be included and return zero Shapley Values."""
+        """Tests that training points slightly outside of the threshold will not be included and return zero Shapley values."""
         test_cases = 6
         for i in (number + 1 for number in range(test_cases)):
             tau = i

--- a/tests/tests_knn_explainer/test_threshold_nn.py
+++ b/tests/tests_knn_explainer/test_threshold_nn.py
@@ -1,4 +1,4 @@
-"""Tests for the threshold nearest-neighbor explainer."""
+"""Tests for the threshold nearest neighbor explainer."""
 
 from __future__ import annotations
 

--- a/tests/tests_knn_explainer/test_threshold_nn.py
+++ b/tests/tests_knn_explainer/test_threshold_nn.py
@@ -110,7 +110,7 @@ class TestThresholdNNExplainer:
 
         Not all Shapley values should be zero.
 
-        Result should be -0.5. Reference: Formula (7) in Wang et al. arXiv:2308.15709v2.
+        Result should be -0.5. Reference: Formula (7) in Wang et al.
         """
         X_train = np.array([[1, 1, 1], [11, 11, 11]])
         y_train = np.array([0, 1])

--- a/tests/tests_knn_explainer/test_threshold_nn.py
+++ b/tests/tests_knn_explainer/test_threshold_nn.py
@@ -110,7 +110,7 @@ class TestThresholdNNExplainer:
 
         Not all Shapley values should be zero.
 
-        Result should be -0.5. Reference: Formula (7) in Wang et. al arXiv:2308.15709v2.
+        Result should be -0.5. Reference: Formula (7) in Wang et al. arXiv:2308.15709v2.
         """
         X_train = np.array([[1, 1, 1], [11, 11, 11]])
         y_train = np.array([0, 1])

--- a/tests/tests_knn_explainer/test_weighted_knn.py
+++ b/tests/tests_knn_explainer/test_weighted_knn.py
@@ -253,7 +253,7 @@ class TestWKNNSanity:
             WeightedKNNExplainer(model, class_index=0)
 
     def test_single_class(self):
-        """Tests that if the training data only consists of a single class, all Shapley Values are zero."""
+        """Tests that if the training data only consists of a single class, all Shapley values are zero."""
         n = 10
         rng = np.random.default_rng(seed=42)
         X_train = rng.normal(size=(n, 2))


### PR DESCRIPTION
- "Shapley values" (instead of "Shapley Values", "SHAP")
- "nearest neighbor model" (instead of "nearest-neighbor model")
  - "k-nearest" should be `$k$-nearest` where possible
  - "TNN" (instead of "TKNN")
  - "threshold" (instead of "thresholded", "tresholded")
- Citations are formatted consistently like `[Exm21]` (instead of `Example et al., 2021`)
- "copula" instead of "Copula" or "Copula's"
- Term "approach" used only where appropriate