### PR TITLE
Add Aas (2021) citations

### DIFF
--- a/docs/source/citations.rst
+++ b/docs/source/citations.rst
@@ -1,6 +1,7 @@
 Citations
 =============
 
+.. [Aas21] Aas, Kjersti, Martin Jullum, and Anders Løland. "Explaining individual predictions when features are dependent: More accurate approximations to Shapley values." Artificial Intelligence 298 (2021): 103502. https://doi.org/10.1016/j.artint.2021.103502
 .. [Jia19] Jia, Ruoxi, et al. "Efficient task-specific data valuation for nearest neighbor algorithms." arXiv preprint arXiv\:1908.08619 (2019). https://doi.org/10.48550/arXiv.1908.08619/
 .. [Wng23] Wang, Jiachen Tianhao, et al. "A privacy-friendly approach to data valuation." Advances in Neural Information Processing Systems 36 (2023): 60429-60467. https://doi.org/10.48550/arXiv.2308.15709
 .. [Wng24] Wang, Jiachen T., Prateek Mittal, and Ruoxi Jia. "Efficient data shapley for weighted nearest neighbor algorithms." International Conference on Artificial Intelligence and Statistics. PMLR, 2024. https://doi.org/10.48550/arXiv.1908.08619

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,7 +35,7 @@ Contents
 
    api
 
-   citations
+   references
 
 .. _quick-start:
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -1,4 +1,4 @@
-Citations
+References
 =============
 
 .. [Aas21] Aas, Kjersti, Martin Jullum, and Anders Løland. "Explaining individual predictions when features are dependent: More accurate approximations to Shapley values." Artificial Intelligence 298 (2021): 103502. https://doi.org/10.1016/j.artint.2021.103502

--- a/shapiq_student/imputer/gaussian/gaussian_copula_imputer.py
+++ b/shapiq_student/imputer/gaussian/gaussian_copula_imputer.py
@@ -18,7 +18,7 @@ from .gaussian_imputer import GaussianImputer
 
 
 class GaussianCopulaImputer(GaussianImputer):
-    r"""Implements a Gaussian copula-based approach for imputation.
+    r"""Implements the Gaussian copula-based approach for imputation according to [Aas21]_.
 
     This method models feature dependence using a Gaussian copula, separating the modeling of marginal distributions
     from their joint dependence structure. Each feature is first transformed to follow a standard normal distribution by

--- a/shapiq_student/imputer/gaussian/gaussian_imputer.py
+++ b/shapiq_student/imputer/gaussian/gaussian_imputer.py
@@ -33,7 +33,7 @@ MAX_UNIQUE_VALUES_FOR_CATEGORICAL = 2
 
 
 class GaussianImputer(ConditionalImputer):
-    r"""Implements the Gaussian-based approach for imputation.
+    r"""Implements the Gaussian-based approach for imputation according to [Aas21]_.
 
     This approach assumes that the features of the background data form a multivariate Gaussian distribution.
     The missing values are imputed by drawing Monte Carlo samples from the conditional distribution given the values of the features present in a coalition.


### PR DESCRIPTION
- Adds a citation of Aas et al. (2021) to the class docstrings of `GaussianImputer` and `GaussianCopulaImputer`
- Renames the 'Citations' section to the more accurate 'References'