### PR TITLE
Fix: name of sample size param in imputers quick start

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,7 +98,7 @@ This example uses the ``GaussianImputer`` to explain the prediction of a random 
     >>> model.fit(X_train, y_train)
     RandomForestRegressor(...)
     >>>
-    >>> gaussian_imputer = GaussianImputer(model=model.predict, data=X_train, n_mc_samples=1000)
+    >>> gaussian_imputer = GaussianImputer(model=model.predict, data=X_train, sample_size=1000)
     >>> explainer = TabularExplainer(
     ...     model=model, data=X_train, index="SII", max_order=2, imputer=gaussian_imputer
     ... )


### PR DESCRIPTION
The parameter is now name `sample_size` instead of `n_mc_samples`. Changed this in the quick start for the imputers